### PR TITLE
Try updating memory for GA

### DIFF
--- a/.github/workflows/generate-instance.yml
+++ b/.github/workflows/generate-instance.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   GenerateCredInstance:
     runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: --max_old_space_size=6144
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Github actions failing with heap out of memory error. Per [this link](https://github.community/t/can-you-help-to-give-more-memory-on-some-project/17892 ) GA runs on Azure with 7GB RAM. Attempting to upgrade our job to 6GB RAM to see if it will fix the error.